### PR TITLE
Osx support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+#OSX Files
+OSX/Lib

--- a/OSX/compile_cli.sh
+++ b/OSX/compile_cli.sh
@@ -1,0 +1,3 @@
+sh compile_lexer.sh
+sh compile_parser.sh
+g++ -I ../Includes/ ../CLI/Main.cpp ./Lib/Lexer.a ./Lib/Parser.a -Wc++11-extensions -std=c++11 -o ./lib/CLI.o

--- a/OSX/compile_lexer.sh
+++ b/OSX/compile_lexer.sh
@@ -1,0 +1,2 @@
+g++ -I ../Includes/ ../Lexer/Lexer.cpp -Wc++11-extensions -std=c++11 -c -o ./lib/Lexer.o
+ar rvs ./Lib/Lexer.a ./Lib/Lexer.o

--- a/OSX/compile_parser.sh
+++ b/OSX/compile_parser.sh
@@ -1,0 +1,2 @@
+g++ -I ../Includes/ ../Parser/Parser.cpp -Wc++11-extensions -std=c++11 -c -o ./lib/Parser.o
+ar rvs ./Lib/Parser.a ./Lib/Parser.o


### PR DESCRIPTION
Since VC++ is not supported on OSX, manual support for compiling on OSX is required.