### PR TITLE
Separator expressions

### DIFF
--- a/Includes/AST.h
+++ b/Includes/AST.h
@@ -123,4 +123,14 @@ namespace AST
 
 		return true;
 	}
+
+	FORCEINLINE bool IsVariable( AST::IExpression* expression )
+	{
+		auto rightExpr = expression;
+
+		while ( rightExpr->Symbol() == Grammar::Symbol::S_DOT )
+			rightExpr = static_cast< CComplexExpression* >( rightExpr )->Rhs();
+
+		return IsNameConstant( rightExpr );
+	}
 }

--- a/Includes/Exception.h
+++ b/Includes/Exception.h
@@ -17,7 +17,7 @@ public:
 	}
 
 	const char* what() const _NOEXCEPT { return m_What.c_str(); }
-private:
+protected:
 	std::string m_What;
 };
 
@@ -49,6 +49,19 @@ public:
 
 	const std::vector< Grammar::SymbolLoc_t >& locations() const { return m_Locations; }
 	const std::vector< std::string >& errors() const { return m_Errors; }
+
+	ParseException operator=( const ParseException& other )
+	{
+		m_Errors.clear();
+		m_Locations.clear();
+
+		m_What = other.m_What;
+
+		std::copy( other.m_Errors.begin(), other.m_Errors.end(), std::back_inserter( m_Errors ) );
+		std::copy( other.m_Locations.begin(), other.m_Locations.end(), std::back_inserter( m_Locations ) );
+
+		return *this;
+	}
 private:
 	std::vector< Grammar::SymbolLoc_t >		m_Locations;
 	std::vector< std::string >				m_Errors;

--- a/Includes/Grammar.h
+++ b/Includes/Grammar.h
@@ -7,19 +7,21 @@ namespace Grammar
 {
 	enum LeftBindingPower
 	{
-		LBP_NAME			= 0,
-		LBP_FEATURE			= 0, // TODO: Split this into multiple (e.g LBP_FORLOOP)
-		LBP_SEMICOLON		= 0,
-		LBP_LOGIC_NOT		= 0,
-		LBP_LOGIC			= 10,
-		LBP_ASSIGN			= 10,
-		LBP_EQUALITY		= 20,
-		LBP_COLON			= 30,
-		LBP_ARITHMETIC_1	= 40,
-		LBP_ARITHMETIC_2	= 50,
-		LBP_ARITHMETIC_3	= 60,
-		LBP_INCDEC			= 70,
-		LBP_OPENBRACKET		= 80,
+		LBP_IMMEDIATE		= -1,
+		LBP_NORMAL			= 0,
+		LBP_NAME			= LBP_NORMAL,
+		LBP_SEMICOLON		= LBP_NORMAL,
+		LBP_COMMA			= 10,
+		LBP_LOGIC_NOT		= 20,
+		LBP_LOGIC			= 30,
+		LBP_ASSIGN			= 30,
+		LBP_EQUALITY		= 40,
+		LBP_ARITHMETIC_1	= 60,
+		LBP_ARITHMETIC_2	= 70,
+		LBP_ARITHMETIC_3	= 80,
+		LBP_INCDEC			= 90,
+		LBP_OPENBRACKET		= 100,
+		LBP_DOT				= 110,
 	};
 
 	struct SymbolLoc_t
@@ -71,7 +73,8 @@ namespace Grammar
 		S_POW,
 		S_MOD,
 		S_SEMICOLON,
-		S_COLON,
+		S_COMMA,
+		S_DOT,
 		S_IF,
 		S_WHILE,
 		S_VAR,
@@ -127,16 +130,17 @@ namespace Grammar
 
 		// Separators
 		{ S_SEMICOLON,		{ ";",			LBP_SEMICOLON,		} },
-		{ S_COLON,			{ ",",			LBP_COLON,			} },
+		{ S_COMMA,			{ ",",			LBP_COMMA,			} },
+		{ S_DOT,			{ ".",			LBP_DOT,			} },
 
 		// Language Features
-		{ S_IF,				{ "if",			LBP_FEATURE,		} },
-		{ S_WHILE,			{ "while",		LBP_FEATURE,		} },
-		{ S_VAR,			{ "var",		-1,					} },
-		{ S_FUNC,			{ "function",	LBP_FEATURE,		} },
-		{ S_RETURN,			{ "return",		LBP_FEATURE,		} },
-		{ S_BREAK,			{ "break",		LBP_FEATURE,		} },
-		{ S_TRUE,			{ "true",		LBP_FEATURE,		} },
-		{ S_FALSE,			{ "false",		LBP_FEATURE,		} },
+		{ S_IF,				{ "if",			LBP_NORMAL,			} },
+		{ S_WHILE,			{ "while",		LBP_NORMAL,			} },
+		{ S_VAR,			{ "var",		LBP_IMMEDIATE,		} },
+		{ S_FUNC,			{ "function",	LBP_NORMAL,			} },
+		{ S_RETURN,			{ "return",		LBP_NORMAL,			} },
+		{ S_BREAK,			{ "break",		LBP_NORMAL,			} },
+		{ S_TRUE,			{ "true",		LBP_NORMAL,			} },
+		{ S_FALSE,			{ "false",		LBP_NORMAL,			} },
 	};
 }

--- a/Parser/Parser.cpp
+++ b/Parser/Parser.cpp
@@ -1,4 +1,4 @@
-#include <functional>
+﻿#include <functional>
 #include <algorithm>
 #include "Parser.h"
 #include "Exception.h"
@@ -116,7 +116,7 @@ namespace Parser
 		void AddExpression( AST::IExpression* expression )
 		{
 			if ( expression )
-			m_Expressions.push_back( expression );
+				m_Expressions.push_back( expression );
 		}
 
 		const std::vector< AST::IExpression* >& GetExpressions() const
@@ -141,6 +141,10 @@ namespace Parser
 		// m_LeftBind and m_RightBind to form a tree like structure
 		auto nextExpression = [ &parserState ]( int rbp = 0 /* Right binding power */ ) -> AST::IExpression*
 		{
+			// Skip surplus semicolons
+			if ( parserState.CurrentSymbol().m_Symbol == Grammar::Symbol::S_SEMICOLON )
+				return NULL;
+
 			// Get the current symbol (and advance to the next one)
 			auto curSymbol = parserState.NextSymbol();
 

--- a/Parser/Parser.cpp
+++ b/Parser/Parser.cpp
@@ -1,4 +1,4 @@
-﻿#include <functional>
+#include <functional>
 #include <algorithm>
 #include "Parser.h"
 #include "Exception.h"
@@ -257,8 +257,8 @@ namespace Parser
 				{
 					symbol.m_LeftBind = [ &nextExpression ]( const ParserSymbol_t& symbol, AST::IExpression* left ) -> AST::IExpression*
 					{
-						if ( !AST::IsNameConstant( left ) )
-							throw ParseException( left->Location(), "Expcected a variable, got: \"" + left->Location().m_SrcToken + "\"" );
+						if ( !AST::IsVariable( left ) )
+							throw ParseException( left->Location(), "Expected a variable, got: \"" + left->Location().m_SrcToken + "\"" );
 
 						return new AST::CComplexExpression( left, NULL, symbol.m_Symbol, symbol.m_Location );
 					};
@@ -267,8 +267,8 @@ namespace Parser
 					{
 						auto right = nextExpression( symbol.m_LBP );
 
-						if ( !AST::IsNameConstant( right ) )
-							throw ParseException( right->Location(), "Expcected a variable, got: \"" + right->Location().m_SrcToken + "\"" );
+						if ( !AST::IsVariable( right ) )
+							throw ParseException( right->Location(), "Expected a variable, got: \"" + right->Location().m_SrcToken + "\"" );
 
 						return new AST::CComplexExpression( NULL, right, symbol.m_Symbol, symbol.m_Location );
 					};
@@ -285,8 +285,16 @@ namespace Parser
 					{
 						auto right = nextExpression( symbol.m_LBP );
 
-						if ( !AST::IsNameConstant( left ) )
-							throw ParseException( left->Location(), "Expcected a variable, got: \"" + left->Location().m_SrcToken + "\"" );
+						if ( symbol.m_Symbol == Grammar::Symbol::S_ASSIGN )
+						{
+							if ( !AST::IsVariable( left ) && left->Symbol() != Grammar::Symbol::S_VAR )
+								throw ParseException( left->Location(), "Expected a variable, got: \"" + left->Location().m_SrcToken + "\"" );
+						}
+						else
+						{
+							if ( !AST::IsVariable( left ) )
+								throw ParseException( left->Location(), "Expected a variable, got: \"" + left->Location().m_SrcToken + "\"" );
+						}
 
 						return new AST::CComplexExpression( left, right, symbol.m_Symbol, symbol.m_Location );
 					};
@@ -319,7 +327,7 @@ namespace Parser
 						auto right = nextExpression( symbol.m_LBP );
 
 						if ( !AST::IsNameConstant( right ) )
-							throw ParseException( right->Location(), "Expcected a variable, got: \"" + right->Location().m_SrcToken + "\"" );
+							throw ParseException( right->Location(), "Expected a variable name, got: \"" + right->Location().m_SrcToken + "\"" );
 
 						return new AST::CSimpleExpression( right, symbol.m_Symbol, symbol.m_Location );
 					};

--- a/Shared/AST.cpp
+++ b/Shared/AST.cpp
@@ -26,8 +26,8 @@ namespace AST
 		std::string output = std::string( indent - 1 < 0 ? indent : indent - 1, '\t' ) + "{\n";
 		output += std::string( indent, '\t' ) + "type: COMPLEX\n";
 		output += std::string( indent, '\t' ) + "token: " + token + "\n";
-		output += std::string( indent, '\t' ) + "lhs: \n" + m_LHS->ToString( indent + 1 );
-		output += std::string( indent, '\t' ) + "rhs: \n" + m_RHS->ToString( indent + 1 );
+		output += std::string( indent, '\t' ) + "lhs: " + ( m_LHS ? "\n" + m_LHS->ToString( indent + 1 ) : "NULL\n" );
+		output += std::string( indent, '\t' ) + "rhs: " + ( m_RHS ? "\n" + m_RHS->ToString( indent + 1 ) : "NULL\n" );
 		output += std::string( indent - 1 < 0 ? indent : indent - 1, '\t' ) + "}\n";
 		return output;
 	}
@@ -50,7 +50,7 @@ namespace AST
 		std::string output = std::string( indent - 1 < 0 ? indent : indent - 1, '\t' ) + "{\n";
 		output += std::string( indent, '\t' ) + "type: SIMPLE\n";
 		output += std::string( indent, '\t' ) + "token: " + token + "\n";
-		output += std::string( indent, '\t' ) + "expression: \n" + m_Expression->ToString( indent + 1 );
+		output += std::string( indent, '\t' ) + "expression: " + ( m_Expression ? "\n" + m_Expression->ToString( indent + 1 ) : "NULL\n" );
 		output += std::string( indent - 1 < 0 ? indent : indent - 1, '\t' ) + "}\n";
 		return output;
 	}
@@ -93,7 +93,7 @@ namespace AST
 		output += std::string( indent, '\t' ) + "items: [\n";
 
 		for ( auto expression : m_List )
-			output += expression->ToString( indent + 1 );
+			output += expression ? expression->ToString( indent + 1 ) : "NULL\n";
 
 		output += std::string( indent - 1 < 0 ? indent : indent - 1, '\t' ) + "]\n" + "}\n";
 		return output;

--- a/UnitTests/ParserTests.cpp
+++ b/UnitTests/ParserTests.cpp
@@ -256,5 +256,132 @@ void RunParserTests()
 		UTEST_CASE_CLOSED();
 	}( );
 
+	UTEST_CASE( "Dot operator (.)" )
+	{
+		auto syntaxTree = Parser::Parse( Lexer::Parse( "a.b = 4.2; a1.b2.c3.d4 || ++a1.b2; 4.5; 444.952;" ) );
+
+		UTEST_ASSERT( syntaxTree.size() == 4 );
+		UTEST_ASSERT( syntaxTree[ 0 ]->Type() == AST::ExpressionType::ET_COMPLEX );
+		UTEST_ASSERT( syntaxTree[ 0 ]->Symbol() == Grammar::Symbol::S_ASSIGN );
+		UTEST_ASSERT( syntaxTree[ 1 ]->Type() == AST::ExpressionType::ET_COMPLEX );
+		UTEST_ASSERT( syntaxTree[ 1 ]->Symbol() == Grammar::Symbol::S_LOGIC_OR );
+		UTEST_ASSERT( syntaxTree[ 2 ]->Type() == AST::ExpressionType::ET_VALUE );
+		UTEST_ASSERT( syntaxTree[ 2 ]->Symbol() == Grammar::Symbol::S_DBLCNST );
+		UTEST_ASSERT( syntaxTree[ 3 ]->Type() == AST::ExpressionType::ET_VALUE );
+		UTEST_ASSERT( syntaxTree[ 3 ]->Symbol() == Grammar::Symbol::S_DBLCNST );
+
+		UTEST_ASSERT( static_cast< AST::CComplexExpression* >( syntaxTree[ 0 ] )->Lhs()->Type() == AST::ExpressionType::ET_COMPLEX );
+		UTEST_ASSERT( static_cast< AST::CComplexExpression* >( syntaxTree[ 0 ] )->Lhs()->Symbol() == Grammar::Symbol::S_DOT );
+		UTEST_ASSERT(
+			static_cast< AST::CComplexExpression* >(
+				static_cast< AST::CComplexExpression* >( syntaxTree[ 0 ] )->Lhs()
+				)->Lhs()->Type() == AST::ExpressionType::ET_VALUE );
+		UTEST_ASSERT(
+			static_cast< AST::CComplexExpression* >(
+				static_cast< AST::CComplexExpression* >( syntaxTree[ 0 ] )->Lhs()
+				)->Lhs()->Symbol() == Grammar::Symbol::S_NAME );
+		UTEST_ASSERT(
+			static_cast< AST::CValueExpression* >( 
+				static_cast< AST::CComplexExpression* >(
+					static_cast< AST::CComplexExpression* >( syntaxTree[ 0 ] )->Lhs()
+				)->Lhs() )->Value().GetType() == Value::ValueType::VT_STRING );
+		UTEST_ASSERT(
+			static_cast< AST::CValueExpression* >(
+				static_cast< AST::CComplexExpression* >(
+					static_cast< AST::CComplexExpression* >( syntaxTree[ 0 ] )->Lhs()
+					)->Lhs() )->Value().GetString() == "a" );
+		UTEST_ASSERT(
+			static_cast< AST::CValueExpression* >(
+				static_cast< AST::CComplexExpression* >(
+					static_cast< AST::CComplexExpression* >( syntaxTree[ 0 ] )->Lhs()
+					)->Rhs() )->Value().GetString() == "b" );
+		UTEST_ASSERT(
+			static_cast< AST::CComplexExpression* >(
+				static_cast< AST::CComplexExpression* >( syntaxTree[ 0 ] )->Rhs()
+				)->Type() == AST::ExpressionType::ET_VALUE );
+		UTEST_ASSERT( static_cast< AST::CComplexExpression* >( syntaxTree[ 0 ] )->Rhs()->Symbol() == Grammar::Symbol::S_DBLCNST );
+		UTEST_ASSERT(
+			static_cast< AST::CValueExpression* >(
+				static_cast< AST::CComplexExpression* >( syntaxTree[ 0 ] )->Rhs()
+			)->Value().GetType() == Value::ValueType::VT_DOUBLE );
+		UTEST_ASSERT(
+			static_cast< AST::CValueExpression* >(
+				static_cast< AST::CComplexExpression* >( syntaxTree[ 0 ] )->Rhs()
+				)->Value().GetDouble() == 4.2 );
+
+		UTEST_ASSERT( static_cast< AST::CComplexExpression* >( syntaxTree[ 1 ] )->Lhs()->Type() == AST::ExpressionType::ET_COMPLEX );
+		UTEST_ASSERT( static_cast< AST::CComplexExpression* >( syntaxTree[ 1 ] )->Lhs()->Symbol() == Grammar::Symbol::S_DOT );
+		UTEST_ASSERT(
+			static_cast< AST::CComplexExpression* >(
+				static_cast< AST::CComplexExpression* >( syntaxTree[ 1 ] )->Lhs()
+				)->Rhs()->Type() == AST::ExpressionType::ET_VALUE );
+		UTEST_ASSERT(
+			static_cast< AST::CValueExpression* >(
+				static_cast< AST::CComplexExpression* >(
+					static_cast< AST::CComplexExpression* >( syntaxTree[ 1 ] )->Lhs()
+				)->Rhs() )->Value().GetType() == Value::ValueType::VT_STRING );
+		UTEST_ASSERT(
+			static_cast< AST::CValueExpression* >(
+				static_cast< AST::CComplexExpression* >(
+					static_cast< AST::CComplexExpression* >( syntaxTree[ 1 ] )->Lhs()
+					)->Rhs() )->Value().GetString() == "d4" );
+		UTEST_ASSERT(
+			static_cast< AST::CComplexExpression* >(
+				static_cast< AST::CComplexExpression* >( syntaxTree[ 1 ] )->Lhs()
+				)->Lhs()->Type() == AST::ExpressionType::ET_COMPLEX );
+		UTEST_ASSERT(
+			static_cast< AST::CComplexExpression* >(
+				static_cast< AST::CComplexExpression* >( syntaxTree[ 1 ] )->Lhs()
+				)->Lhs()->Symbol() == Grammar::Symbol::S_DOT );
+		UTEST_ASSERT(
+			static_cast< AST::CComplexExpression* >(
+				static_cast< AST::CComplexExpression* >(
+					static_cast< AST::CComplexExpression* >( syntaxTree[ 1 ] )->Lhs()
+					)->Lhs() )->Rhs()->Type() == AST::ExpressionType::ET_VALUE );
+		UTEST_ASSERT(
+			static_cast< AST::CValueExpression* >(
+				static_cast< AST::CComplexExpression* >(
+					static_cast< AST::CComplexExpression* >(
+						static_cast< AST::CComplexExpression* >( syntaxTree[ 1 ] )->Lhs()
+						)->Lhs() )->Rhs() )->Value().GetString() == "c3" );
+
+		UTEST_ASSERT( static_cast< AST::CValueExpression* >( syntaxTree[ 2 ] )->Value().GetType() == Value::ValueType::VT_DOUBLE );
+		UTEST_ASSERT( static_cast< AST::CValueExpression* >( syntaxTree[ 2 ] )->Value().GetDouble() == 4.5 );
+		UTEST_ASSERT( static_cast< AST::CValueExpression* >( syntaxTree[ 3 ] )->Value().GetType() == Value::ValueType::VT_DOUBLE );
+		UTEST_ASSERT( static_cast< AST::CValueExpression* >( syntaxTree[ 3 ] )->Value().GetDouble() == 444.952 );
+
+		UTEST_ASSERT( static_cast< AST::CComplexExpression* >( syntaxTree[ 1 ] )->Rhs()->Type() == AST::ExpressionType::ET_COMPLEX );
+		UTEST_ASSERT( static_cast< AST::CComplexExpression* >( syntaxTree[ 1 ] )->Rhs()->Symbol() == Grammar::Symbol::S_INCREMENT );
+
+		UTEST_CASE_CLOSED();
+	}( );
+
+	UTEST_CASE( "Other separators (, ;)" )
+	{
+		auto syntaxTree = Parser::Parse( Lexer::Parse( ";;; ;;; ; ;;" ) );
+
+		UTEST_ASSERT( syntaxTree.size() == 0 );
+
+		syntaxTree = Parser::Parse( Lexer::Parse( "a, b, c + 1, c * 2 == 4;" ) );
+
+		UTEST_ASSERT( syntaxTree.size() == 1 );
+		UTEST_ASSERT( syntaxTree[ 0 ]->Type() == AST::ExpressionType::ET_LIST );
+		UTEST_ASSERT( static_cast< AST::CListExpression* >( syntaxTree[ 0 ] )->List().size() == 4 );
+		UTEST_ASSERT( static_cast< AST::CListExpression* >( syntaxTree[ 0 ] )->List()[ 0 ]->Type() == AST::ExpressionType::ET_VALUE );
+		UTEST_ASSERT(
+			static_cast< AST::CValueExpression* >(
+				static_cast< AST::CListExpression* >( syntaxTree[ 0 ] )->List()[ 0 ]
+				)->Value().GetType() == Value::ValueType::VT_STRING );
+		UTEST_ASSERT(
+			static_cast< AST::CValueExpression* >(
+				static_cast< AST::CListExpression* >( syntaxTree[ 0 ] )->List()[ 0 ]
+				)->Value().GetString() == "a" );
+		UTEST_ASSERT( static_cast< AST::CListExpression* >( syntaxTree[ 0 ] )->List()[ 2 ]->Type() == AST::ExpressionType::ET_COMPLEX );
+		UTEST_ASSERT( static_cast< AST::CListExpression* >( syntaxTree[ 0 ] )->List()[ 2 ]->Symbol() == Grammar::Symbol::S_ADD );
+		UTEST_ASSERT( static_cast< AST::CListExpression* >( syntaxTree[ 0 ] )->List()[ 3 ]->Symbol() == Grammar::Symbol::S_EQUALS );
+
+		UTEST_CASE_CLOSED();
+	}( );
+
 	UTEST_END();
 }


### PR DESCRIPTION
- Added dot and comma (, .) separator operators
- Added `operator=` to `ParseException` class
- Fixed AST stringify with NULL subnodes
- Fix parsing errors with additional semicolons
